### PR TITLE
[FIX] Prevenir que el documento se desplaze verticalmente

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,12 @@
 <head>
 	<title>PING PONG</title>
 	<style>
-		body{
+		html {
+                        overflow: hidden;
+                }
+                body{
+                        width: 100vw;
+                        height: 100vh;
 			padding:0;
 			margin:0;
 			overflow: hidden;
@@ -14,6 +19,6 @@
 	<canvas id="canvas">
 	Su navegador no tiene soporte para mostrar el contenido
    	</canvas>
-<script src="script.js"></script>
+        <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Este commit evita que el documento pueda ser desplazado verticalmente por el usuario mediante la rueda del raton o las teclas de navegacion, lo cual era posible debido a un trozo de pagina desbordandose debajo del canvas del juego.
